### PR TITLE
Chenge jinja Delimiters to "[["

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,30 @@ If you find this addon useful, please consider supporting the development of thi
 
 4. Find the ``jinja2config`` addon now the repository has been added and install it.
 
+## Configuration
+
+### Options
+
+- **config_dir**: The directory to watch for Jinja2 templates (default: `/config`)
+- **log_level**: Set the logging level (trace, debug, info, notice, warning, error, fatal)
+- **use_square_brackets**: Use square bracket delimiters `[[ ]]` instead of curly braces `{{ }}` (default: false)
+
+### Custom Delimiters
+
+If you need to use Jinja2 templates that conflict with other templating systems (like Home Assistant's own templating), you can enable the `use_square_brackets` option. This changes the Jinja2 delimiters as follows:
+
+- Variables: `{{ }}` → `[[ ]]`
+- Blocks: `{% %}` → `[% %]`
+- Comments: `{# #}` → `[# #]`
+
+Example configuration with custom delimiters enabled:
+
+```yaml
+config_dir: /config
+log_level: info
+use_square_brackets: true
+```
+
 ## Example
 
 I set up smart thermostats to control the underfloor heating for multiple rooms, requiring a certain amount of similar config per room. Using a template the amount of hand written yaml is greatly reduced, making it easier to manage and change as needed.

--- a/README.md
+++ b/README.md
@@ -21,29 +21,13 @@ If you find this addon useful, please consider supporting the development of thi
 
 4. Find the ``jinja2config`` addon now the repository has been added and install it.
 
-## Configuration
+## Delimiters
 
-### Options
+This addon uses square bracket delimiters instead of the default curly braces to avoid conflicts with Home Assistant's templating system:
 
-- **config_dir**: The directory to watch for Jinja2 templates (default: `/config`)
-- **log_level**: Set the logging level (trace, debug, info, notice, warning, error, fatal)
-- **use_square_brackets**: Use square bracket delimiters `[[ ]]` instead of curly braces `{{ }}` (default: false)
-
-### Custom Delimiters
-
-If you need to use Jinja2 templates that conflict with other templating systems (like Home Assistant's own templating), you can enable the `use_square_brackets` option. This changes the Jinja2 delimiters as follows:
-
-- Variables: `{{ }}` → `[[ ]]`
-- Blocks: `{% %}` → `[% %]`
-- Comments: `{# #}` → `[# #]`
-
-Example configuration with custom delimiters enabled:
-
-```yaml
-config_dir: /config
-log_level: info
-use_square_brackets: true
-```
+- Variables: `[[ variable ]]` instead of `{{ variable }}`
+- Blocks: `[% for item in items %]` instead of `{% for item in items %}`
+- Comments: `[# comment #]` instead of `{# comment #}`
 
 ## Example
 
@@ -54,7 +38,7 @@ The following is a sample from my heating system, setting up the climate entitie
 Any changes to the template result in the yaml file being regenerated automatically. Any errors are written to an error file alongside the template.
 
 ```
-{% set rooms = [
+[% set rooms = [
     {
         "name": "Living Room",
         "id_prefix": "living_room",
@@ -69,9 +53,9 @@ Any changes to the template result in the yaml file being regenerated automatica
         "ki": 0.001,
         "kd": 1000
     }
-] %}
+] %]
 
-{% set presets = {
+[% set presets = {
     "min": 7,
     "max": 25,
     "away": 7,
@@ -79,28 +63,28 @@ Any changes to the template result in the yaml file being regenerated automatica
     "sleep": 17,
     "comfort": 19,
     "boost": 21
-} %}
+} %]
 
 climate:
-  {% for room in rooms %}
+  [% for room in rooms %]
   - platform: smart_thermostat
-    name: {{ room.name }} Smart Thermostat
-    unique_id: {{ room.id_prefix }}_smart_thermostat
-    heater: switch.{{ room.id_prefix }}_heating
-    target_sensor: sensor.{{ room.id_prefix }}_temperature
+    name: [[ room.name ]] Smart Thermostat
+    unique_id: [[ room.id_prefix ]]_smart_thermostat
+    heater: switch.[[ room.id_prefix ]]_heating
+    target_sensor: sensor.[[ room.id_prefix ]]_temperature
     ac_mode: False
-    kp: {{ room.kp }}
-    ki: {{ room.ki }}
-    kd: {{ room.kd }}
+    kp: [[ room.kp ]]
+    ki: [[ room.ki ]]
+    kd: [[ room.kd ]]
     keep_alive: 00:01:00
     pwm: 00:25:00
     min_cycle_duration: 00:5:00
-    {%- for preset in presets %}
-    {{ preset }}_temp: {{ presets[preset] }}
-    {%- endfor %}
-    target_temp: {{ presets["away"] }}
+    [%- for preset in presets %]
+    [[ preset ]]_temp: [[ presets[preset] ]]
+    [%- endfor %]
+    target_temp: [[ presets["away"] ]]
     debug: true
-  {% endfor %}
+  [% endfor %]
 ```
 
 ## Credits

--- a/config.yaml
+++ b/config.yaml
@@ -14,8 +14,6 @@ arch:
 options:
   log_level: debug
   config_dir: "/config"
-  use_square_brackets: false
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)
   config_dir: str
-  use_square_brackets: bool

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "Jinja2Config"
 description: "Compile Home Assistant config files from Jinja2 templates"
-version: "1.0.4"
+version: "1.1.0"
 slug: "jinja2config"
 init: false
 map:
@@ -14,6 +14,8 @@ arch:
 options:
   log_level: debug
   config_dir: "/config"
+  use_square_brackets: false
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)
   config_dir: str
+  use_square_brackets: bool

--- a/rootfs/usr/bin/generate_jinja_customization.py
+++ b/rootfs/usr/bin/generate_jinja_customization.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""
+Generate Jinja2 customization file for j2cli
+"""
+
+def j2_environment_params():
+    """
+    Return custom delimiter parameters for Jinja2 environment
+    Changes delimiters from {{ }} to [[ ]] and from {% %} to [% %]
+    """
+    return dict(
+        variable_start_string='[[',
+        variable_end_string=']]',
+        block_start_string='[%',
+        block_end_string='%]',
+        comment_start_string='[#',
+        comment_end_string='#]'
+    )

--- a/rootfs/usr/bin/jinja2config.sh
+++ b/rootfs/usr/bin/jinja2config.sh
@@ -1,7 +1,6 @@
 #!/command/with-contenv bashio
 HASS_CONFIG_DIR=$(bashio::config 'config_dir')
-USE_SQUARE_BRACKETS=$(bashio::config 'use_square_brackets')
-CUSTOMIZE_FILE=""
+CUSTOMIZE_FILE="/usr/bin/generate_jinja_customization.py"
 
 if ! type jinja > /dev/null 2>&1; then
   echo "jinja-cli must be installed: pip install jinja-cli (https://pypi.org/project/jinja-cli/)"
@@ -12,12 +11,6 @@ if ! type prettier > /dev/null 2>&1; then
   echo "Prettier must be installed: apt-get install nodejs npm && npm install -g prettier"
   sleep 1
   exit 1
-fi
-
-# Set up custom delimiters if enabled
-if [ "$USE_SQUARE_BRACKETS" = "true" ]; then
-  CUSTOMIZE_FILE="/usr/bin/generate_jinja_customization.py"
-  echo "Using square bracket delimiters: [[ ]] instead of {{ }}"
 fi
 
 remove() {
@@ -31,15 +24,8 @@ compile() {
   ERROR_LOG_FILE="$1$2.errors.log"
   OUTPUT_FILE="$1${2/.jinja}"
   echo "# DO NOT EDIT: Generated from: $2" > "$OUTPUT_FILE"
-
-  # Build jinja command with optional customization file
-  JINJA_CMD="jinja"
-  if [ -n "$CUSTOMIZE_FILE" ]; then
-    JINJA_CMD="jinja --customize $CUSTOMIZE_FILE"
-  fi
-
   # Log any errors to an .errors.log file, delete if successful
-  if $JINJA_CMD "$1$2" >> "$OUTPUT_FILE" 2> "$ERROR_LOG_FILE"; then
+  if jinja --customize "$CUSTOMIZE_FILE" "$1$2" >> "$OUTPUT_FILE" 2> "$ERROR_LOG_FILE"; then
     (rm -f "$ERROR_LOG_FILE" || true)
     echo "Formatting $OUTPUT_FILE with Prettier..."
     prettier --write "$OUTPUT_FILE" --log-level warn || true


### PR DESCRIPTION
In Home Assistant configuration, you can use Jinja syntax in value_template etc., which will conflict with the conversion performed by this add-on. 
Changing the delimiter of this add-on will avoid the conflict.

Ideally the delimiter should be optional, but I don't know how to achieve that in the add-on UI. I'd be happy to see such a change.